### PR TITLE
Optional uppercase hex codes

### DIFF
--- a/ColorPick.py
+++ b/ColorPick.py
@@ -41,6 +41,10 @@ class ColorPickCommand(sublime_plugin.TextCommand):
         color = proc.communicate()[0]
 
         if color:
+            # upcase color if option set
+            user_settings = sublime.load_settings("Preferences.sublime-settings")
+            if user_settings.get("color_pick_upcase", False):
+                color = color.upper()
             # replace all regions with color
             for region in sel:
                 word = view.word(region)

--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ It's important that you check out the repo as ColorPick as the plugin will look 
 `cmd+shift+c` to insert a color
 
 or bind it to a key of your choosing, the command is `color_pick`
+
+## options
+
+If you prefer your colors to be uppercase (`#FF0000` vs `#ff0000`), set the `color_pick_upcase` option in your user settings (`cmd+comma`)
+
+Example:
+
+```json
+{
+  "font_face": "Menlo",
+  "font_size": 11.0,
+  "tab_size": 2,
+  "word_wrap": true,
+  "wrap_width": 90, 
+  "color_pick_upcase": true
+}
+```


### PR DESCRIPTION
I've added the ability to render hex codes as uppercase via a user setting `color_pick_upcase`. See updated README.md for info.
