### PR TITLE
sublime text 3 beta fix

### DIFF
--- a/ColorPick.py
+++ b/ColorPick.py
@@ -21,7 +21,7 @@ class ColorPickCommand(sublime_plugin.TextCommand):
 
         # make sure color picker binary is executable
         if not os.access(picker_path, os.X_OK):
-            os.chmod(picker_path, 0755)
+            os.chmod(picker_path, 755)
 
         # get the currently selected color - if any
         if len(sel) > 0:


### PR DESCRIPTION
When using ColorPick Plugin with Sublime Text 3 there’s this Error Message:

``` text
File "<frozen importlib._bootstrap>", line 562, in module_for_loader_wrapper
File "<frozen importlib._bootstrap>", line 854, in _load_module
File "<frozen importlib._bootstrap>", line 981, in get_code
File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
File "/Users/ephigenia/Library/Application Support/Sublime Text 3/Packages/ColorPick/ColorPick.py", line 24
    os.chmod(picker_path, 00755)
                              ^
SyntaxError: invalid token
```

This can be fixed by removing the `0` from the `chmod` command in line 24. So it works with `755` instead of `0755`.
